### PR TITLE
Add reduce algorithm listing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_CXX_COMPILER "/opt/apps/clang/11.0.1/bin/clang++")
+set(CMAKE_CXX_STANDARD 17)
+project(hpx_overview CXX)
+find_package(HPX REQUIRED)
+add_executable(listing3_1 listing3_1.cpp)
+target_link_libraries(listing3_1 HPX::hpx HPX::wrap_main HPX::iostreams_component)

--- a/listing3_1.cpp
+++ b/listing3_1.cpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2014-2020 STE||AR GROUP
+
+#include <hpx/algorithm.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/iostream.hpp>
+
+#include <algorithm>
+#include <vector>
+
+int hpx_main(int, char **) {
+  std::vector<int> v(10, 1);
+
+  ///////////////////////////////////////////////////////////////
+  auto sum1 = std::reduce(std::begin(v), std::end(v), 0);
+
+  ///////////////////////////////////////////////////////////////
+  auto sum2 = hpx::reduce(v.begin(), v.end(), 0);
+
+  ///////////////////////////////////////////////////////////////
+  auto sum3 = hpx::reduce(hpx::execution::seq, v.begin(), v.end(), 0);
+
+  ///////////////////////////////////////////////////////////////
+  auto sum4 = hpx::reduce(hpx::execution::par, v.begin(), v.end(), 0);
+
+  hpx::cout << sum1 << " " << sum2 << " " << sum3 << " " << sum4 << hpx::endl;
+
+  return hpx::finalize();
+}
+
+int main(int argc, char *argv[]) 
+{ 
+  return hpx::init(argc, argv);
+}


### PR DESCRIPTION
This adds a listing that demonstrates `std::reduce`, `hpx::reduce(seq)` and `hpx::reduce(par)`.

@diehlpk  please update me on the naming convention you want to go with here and how do you want for the files to be organized. 